### PR TITLE
build: fix macOS KawPoW and DashBLS GMP checks

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1350,11 +1350,11 @@ kerrigan_util_LDADD += $(BOOST_LIBS) $(GMP_LIBS) $(SODIUM_LIBS)
 # kerriganconsensus library #
 if BUILD_BITCOIN_LIBS
 include_HEADERS = script/bitcoinconsensus.h
-libkerriganconsensus_la_SOURCES = support/cleanse.cpp $(crypto_libbitcoin_crypto_base_la_SOURCES) $(crypto_libbitcoin_crypto_sph_la_SOURCES) $(libbitcoin_consensus_a_SOURCES)
+libkerriganconsensus_la_SOURCES = support/cleanse.cpp $(crypto_libbitcoin_crypto_base_la_SOURCES) $(crypto_libbitcoin_crypto_sph_la_SOURCES) $(crypto_libbitcoin_crypto_kawpow_la_SOURCES) $(libbitcoin_consensus_a_SOURCES)
 
 libkerriganconsensus_la_LDFLAGS = $(AM_LDFLAGS) -no-undefined $(RELDFLAGS)
 libkerriganconsensus_la_LIBADD = $(LIBDASHBLS) $(LIBSECP256K1) $(GMP_LIBS) $(SODIUM_LIBS)
-libkerriganconsensus_la_CPPFLAGS = $(AM_CPPFLAGS) -I$(builddir)/obj -I$(srcdir)/secp256k1/include -DBUILD_BITCOIN_INTERNAL -DDISABLE_OPTIMIZED_SHA256
+libkerriganconsensus_la_CPPFLAGS = $(AM_CPPFLAGS) -I$(builddir)/obj -I$(srcdir)/secp256k1/include -I$(srcdir)/crypto/ethash/include -DBUILD_BITCOIN_INTERNAL -DDISABLE_OPTIMIZED_SHA256
 libkerriganconsensus_la_CPPFLAGS += -isystem$(srcdir)/dashbls/include -isystem$(srcdir)/dashbls/depends/relic/include -isystem$(srcdir)/dashbls/depends/minialloc/include
 libkerriganconsensus_la_CPPFLAGS += -isystem$(srcdir)/immer
 libkerriganconsensus_la_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)

--- a/src/dashbls/configure.ac
+++ b/src/dashbls/configure.ac
@@ -172,6 +172,10 @@ AC_DEFUN([GMP_CHECK],[
             gmp_major_version=6
             gmp_minor_version=3
             ;;
+          *)
+            gmp_major_version=6
+            gmp_minor_version=2
+            ;;
         esac
         ;;
       *)


### PR DESCRIPTION
Fixes two macOS build issues found while building Kerrigan v1.1.2 for Apple Silicon and Intel.

1. Adds KawPoW/ProgPoW sources and Ethash include path to libkerriganconsensus so macOS builds no longer fail with undefined progpow::hash_no_verify.

2. Fixes DashBLS GMP version detection on macOS Intel/x86_64 by setting the Darwin non-aarch GMP minimum to 6.2, preventing configure from generating an invalid empty GMP version check.

Tested:
- macOS ARM64 build completed
- macOS x86_64 build completed
- Both app bundles launched successfully