### PR TITLE
depends: fix freetype build with CMake 4

### DIFF
--- a/depends/packages/freetype.mk
+++ b/depends/packages/freetype.mk
@@ -7,6 +7,7 @@ $(package)_build_subdir=build
 
 define $(package)_set_vars
   $(package)_config_opts := -DCMAKE_BUILD_TYPE=None -DBUILD_SHARED_LIBS=TRUE
+  $(package)_config_opts += -DCMAKE_POLICY_VERSION_MINIMUM=3.5
   $(package)_config_opts += -DCMAKE_DISABLE_FIND_PACKAGE_ZLIB=TRUE -DCMAKE_DISABLE_FIND_PACKAGE_PNG=TRUE
   $(package)_config_opts += -DCMAKE_DISABLE_FIND_PACKAGE_HarfBuzz=TRUE -DCMAKE_DISABLE_FIND_PACKAGE_BZip2=TRUE
   $(package)_config_opts += -DCMAKE_DISABLE_FIND_PACKAGE_BrotliDec=TRUE


### PR DESCRIPTION
Fixes the depends freetype build on systems with CMake 4.x, such as Ubuntu 26.04.

CMake 4 removed compatibility with projects declaring very old cmake_minimum_required versions. freetype 2.11.0 fails during configure unless CMAKE_POLICY_VERSION_MINIMUM is set.

This adds:

-DCMAKE_POLICY_VERSION_MINIMUM=3.5

to depends/packages/freetype.mk.

Tested:
- Ubuntu 26.04 LTS ARM64 / aarch64
- make -C depends HOST=aarch64-linux-gnu completed
- ./configure completed
- make completed
- Produced working Linux ARM64 binaries:
  - kerrigand
  - kerrigan-cli
  - kerrigan-tx
  - kerrigan-wallet
  - kerrigan-util