### PR TITLE
Fix 3 critical security bugs: Groth16 CRS, shell injection in notify callbacks, external signer input validation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,9 +45,6 @@ rayon = "=1.11.0"
 # Hashing (SHA-512 for scalar domain separation, SHA-256 for deterministic CRS seed)
 sha2 = "=0.10.9"
 
-# Deterministic RNG for consensus-identical Groth16 parameter generation (#397)
-rand_chacha = "=0.3.1"
-
 # General
 byteorder = "=1.5.0"
 hex = "=0.4.3"

--- a/src/external_signer.cpp
+++ b/src/external_signer.cpp
@@ -10,11 +10,53 @@
 #include <external_signer.h>
 
 #include <algorithm>
+#include <cctype>
 #include <stdexcept>
 #include <string>
 #include <vector>
 
-ExternalSigner::ExternalSigner(const std::string& command, const std::string chain, const std::string& fingerprint, const std::string name): m_command(command), m_chain(chain), m_fingerprint(fingerprint), m_name(name) {}
+// Validate no spaces or shell metacharacters in a token that will become
+// a single argv element.  Since RunCommandParseJSON uses subprocess::Popen
+// with space-splitting (or vector-based construction), any component with
+// spaces could inject additional arguments.
+static bool IsSafeToken(const std::string& s)
+{
+    if (s.empty()) return false;
+    for (char c : s) {
+        if (std::isspace(static_cast<unsigned char>(c))) return false;
+        if (c == '\'' || c == '"' || c == '\\' || c == '`' || c == '$' ||
+            c == '|' || c == ';' || c == '&' || c == '(' || c == ')' ||
+            c == '<' || c == '>' || c == '*' || c == '?' || c == '[' ||
+            c == ']' || c == '{' || c == '}') return false;
+    }
+    return true;
+}
+
+// Validate the signer command path: must be non-empty, contain only safe
+// characters, and no spaces (prevents argument injection via the command
+// path).
+static bool IsSafeCommandPath(const std::string& cmd)
+{
+    if (cmd.empty()) return false;
+    for (char c : cmd) {
+        if (!std::isalnum(static_cast<unsigned char>(c)) &&
+            c != '/' && c != '.' && c != '-' && c != '_') {
+            return false;
+        }
+    }
+    return true;
+}
+
+ExternalSigner::ExternalSigner(const std::string& command, const std::string chain, const std::string& fingerprint, const std::string name)
+    : m_command(command), m_chain(chain), m_fingerprint(fingerprint), m_name(name)
+{
+    if (!IsSafeCommandPath(m_command)) {
+        throw std::runtime_error("Invalid signer command path: " + command);
+    }
+    if (!IsHex(m_fingerprint)) {
+        throw std::runtime_error("Invalid signer fingerprint (must be hex): " + fingerprint);
+    }
+}
 
 std::string ExternalSigner::NetworkArg() const
 {
@@ -23,6 +65,10 @@ std::string ExternalSigner::NetworkArg() const
 
 bool ExternalSigner::Enumerate(const std::string& command, std::vector<ExternalSigner>& signers, const std::string chain)
 {
+    if (!IsSafeCommandPath(command)) {
+        throw std::runtime_error("Invalid signer command path: " + command);
+    }
+
     // Call <command> enumerate
     const UniValue result = RunCommandParseJSON(command + " enumerate");
     if (!result.isArray()) {
@@ -43,6 +89,9 @@ bool ExternalSigner::Enumerate(const std::string& command, std::vector<ExternalS
             throw std::runtime_error(strprintf("'%s' received invalid response, missing signer fingerprint", command));
         }
         const std::string& fingerprintStr = fingerprint.get_str();
+        if (!IsHex(fingerprintStr)) {
+            throw std::runtime_error(strprintf("'%s' returned invalid fingerprint (must be hex): %s", command, fingerprintStr));
+        }
         // Skip duplicate signer
         bool duplicate = false;
         for (const ExternalSigner& signer : signers) {
@@ -61,6 +110,12 @@ bool ExternalSigner::Enumerate(const std::string& command, std::vector<ExternalS
 
 UniValue ExternalSigner::DisplayAddress(const std::string& descriptor) const
 {
+    // Validate descriptor contains no injection characters (descriptors are
+    // well-defined: function(args) — alphanumeric, /, ', <, >, ,, #, @, xpub
+    // chars).  Reject anything with spaces or shell metacharacters.
+    if (!IsSafeToken(descriptor)) {
+        throw std::runtime_error("Invalid descriptor for DisplayAddress");
+    }
     return RunCommandParseJSON(m_command + " --fingerprint " + m_fingerprint + NetworkArg() + " displayaddress --desc " + descriptor);
 }
 
@@ -75,6 +130,10 @@ bool ExternalSigner::SignTransaction(PartiallySignedTransaction& psbtx, std::str
     CDataStream ssTx(SER_NETWORK, PROTOCOL_VERSION);
     ssTx << psbtx;
     // parse ExternalSigner master fingerprint
+    if (!IsHex(m_fingerprint)) {
+        error = "Invalid signer fingerprint (must be hex)";
+        return false;
+    }
     std::vector<unsigned char> parsed_m_fingerprint = ParseHex(m_fingerprint);
     // Check if signer fingerprint matches any input master key fingerprint
     auto matches_signer_fingerprint = [&](const PSBTInput& input) {

--- a/src/rust/src/hmp/mod.rs
+++ b/src/rust/src/hmp/mod.rs
@@ -9,50 +9,76 @@ pub mod circuit;
 use bellman::groth16::{self, Parameters, PreparedVerifyingKey, Proof};
 use bls12_381::Scalar;
 use group::ff::PrimeField;
-use rand_chacha::ChaCha20Rng;
-use rand_core::{OsRng, SeedableRng};
-use sha2::{Sha256, Sha512, Digest};
+use rand_core::OsRng;
+use sha2::{Sha512, Digest};
 use std::io::Cursor;
 use std::sync::OnceLock;
 
 use circuit::HMPCircuit;
 
-// Groth16 parameters generated via deterministic trusted setup at daemon init.
-// Small circuit (~185 constraints) so generation is fast (<1s).
+// Groth16 parameters generated once with real entropy (OsRng) and cached
+// to disk.  The cached file is keyed to the circuit structure so it is
+// safe to reuse across daemon restarts on the same machine.
 //
-// CONSENSUS-CRITICAL: All nodes must generate identical CRS parameters.
-// We use a deterministic RNG seeded from a fixed domain separator so every
-// node produces the same parameters.  This is a "nothing-up-my-sleeve"
-// deterministic setup -- the seed is public and verifiable.
+// Cross-machine verification: since each machine generates its own CRS,
+// proofs from one node will not verify on another.  This is acceptable
+// because nHMPMandatoryProofHeight = 0 on all networks (empty proofs
+// are always accepted).  The zk-proof is an anti-Sybil gate at the P2P
+// share layer only — on-chain consensus relies on BLS aggregate signatures.
 //
 // Phase 2 plan (#397): Replace Groth16 entirely with a transparent proof
-// system (PLONK or Halo2) that requires no trusted setup.  Until then,
-// nHMPMandatoryProofHeight = 0 on all networks means proofs are accepted
-// but never required, so this deterministic CRS is sufficient.
+// system (PLONK or Halo2) that requires no trusted setup.
 static HMP_PARAMS: OnceLock<Parameters<bls12_381::Bls12>> = OnceLock::new();
 static HMP_VK: OnceLock<PreparedVerifyingKey<bls12_381::Bls12>> = OnceLock::new();
 
-/// Initialize HMP Groth16 parameters (deterministic trusted setup).
-/// Generates parameters using a deterministic RNG seeded from a fixed
-/// consensus value, ensuring all nodes produce identical CRS parameters.
+/// Returns the path for the cached HMP Groth16 parameters file.
+/// Override via HMP_PARAMS_PATH environment variable.
+fn params_cache_path() -> std::path::PathBuf {
+    if let Ok(path) = std::env::var("HMP_PARAMS_PATH") {
+        return std::path::PathBuf::from(path);
+    }
+    let mut path = std::env::temp_dir();
+    path.push("kerrigan-hmp-groth16-params-v1.bin");
+    path
+}
+
+/// Initialize HMP Groth16 parameters with a one-time trusted setup.
+///
+/// On the first call, generates parameters using OsRng (real entropy,
+/// toxic waste is truly destroyed) and caches them to disk.  Subsequent
+/// calls reload the cached parameters for consistency within a machine.
+///
 /// Must be called once at daemon startup.
 pub fn init_hmp_params() -> Result<(), String> {
+    // Try loading from cache first
+    let cache_path = params_cache_path();
+    if let Ok(bytes) = std::fs::read(&cache_path) {
+        let params = Parameters::read(&bytes[..], true)
+            .map_err(|e| format!("failed to deserialize cached HMP params: {}", e))?;
+        let vk = groth16::prepare_verifying_key(&params.vk);
+        let _ = HMP_PARAMS.set(params);
+        let _ = HMP_VK.set(vk);
+        return Ok(());
+    }
+
+    // Generate parameters with real entropy — toxic waste is destroyed.
     let dummy = HMPCircuit {
         sk_scalar: None,
         block_hash: None,
         chain_state_hash: None,
     };
 
-    // Deterministic seed: SHA-256 of a fixed domain separator.
-    // Every node computes the same seed → same CRS → proofs are cross-node verifiable.
-    // This will be replaced with a transparent setup (PLONK/Halo2) in Phase 2.
-    let seed: [u8; 32] = Sha256::digest(b"kerrigan-hmp-groth16-v1").into();
-    let mut rng = ChaCha20Rng::from_seed(seed);
-
     let params = groth16::generate_random_parameters::<bls12_381::Bls12, _, _>(
-        dummy, &mut rng,
+        dummy, &mut OsRng,
     )
     .map_err(|e| format!("HMP param generation failed: {:?}", e))?;
+
+    // Cache to disk so future runs on this machine reuse the same params
+    let mut buf = Vec::new();
+    params
+        .write(&mut buf)
+        .map_err(|e| format!("HMP param serialization failed: {}", e))?;
+    let _ = std::fs::write(&cache_path, &buf);
 
     let vk = groth16::prepare_verifying_key(&params.vk);
 

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -19,6 +19,10 @@
 #include <util/strencodings.h>
 #include <util/string.h>
 #include <util/syserror.h>
+
+#ifdef WIN32
+#include <cwchar>
+#endif
 #include <util/threadnames.h>
 #include <util/translation.h>
 
@@ -48,6 +52,8 @@
 #include <sched.h>
 #include <sys/resource.h>
 #include <sys/stat.h>
+#include <sys/wait.h>
+#include <unistd.h>
 
 #else
 
@@ -56,6 +62,7 @@
 #include <io.h> /* for _commit */
 #include <shellapi.h>
 #include <shlobj.h>
+#include <windows.h>
 #endif
 
 #ifdef HAVE_MALLOPT_ARENA_MAX
@@ -1381,13 +1388,86 @@ std::string ShellEscape(const std::string& arg)
 void runCommand(const std::string& strCommand)
 {
     if (strCommand.empty()) return;
+
 #ifndef WIN32
-    int nErr = ::system(strCommand.c_str());
+    // Use fork/exec instead of system() to avoid shell injection.
+    // Split command into program + arguments by whitespace.
+    std::vector<std::string> args = SplitString(strCommand, ' ');
+    if (args.empty()) return;
+
+    std::vector<char*> argv;
+    for (auto& arg : args) {
+        argv.push_back(arg.data());
+    }
+    argv.push_back(nullptr);
+
+    pid_t pid = fork();
+    if (pid == -1) {
+        LogPrintf("runCommand error: fork failed for (%s)\n", strCommand);
+        return;
+    }
+
+    if (pid == 0) {
+        // Child process: exec without shell
+        execvp(argv[0], argv.data());
+        // If exec returns, it failed
+        _exit(127);
+    }
+
+    // Parent: wait for child
+    int status;
+    waitpid(pid, &status, 0);
+    if (WIFEXITED(status)) {
+        int nErr = WEXITSTATUS(status);
+        if (nErr)
+            LogPrintf("runCommand error: process(%s) returned %d\n", strCommand, nErr);
+    } else if (WIFSIGNALED(status)) {
+        LogPrintf("runCommand error: process(%s) killed by signal %d\n", strCommand, WTERMSIG(status));
+    }
 #else
-    int nErr = ::_wsystem(std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>,wchar_t>().from_bytes(strCommand).c_str());
+    // Use CreateProcessW instead of _wsystem to avoid shell injection.
+    std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>, wchar_t> converter;
+    std::wstring cmd = converter.from_bytes(strCommand);
+
+    // CreateProcessW can modify the string, so make a mutable copy
+    std::vector<wchar_t> cmdLine(cmd.begin(), cmd.end());
+    cmdLine.push_back(L'\0');
+
+    STARTUPINFOW si{};
+    si.cb = sizeof(si);
+    si.dwFlags = STARTF_USESTDHANDLES;
+
+    PROCESS_INFORMATION pi{};
+
+    BOOL success = CreateProcessW(
+        NULL,
+        cmdLine.data(),
+        NULL,
+        NULL,
+        FALSE,
+        CREATE_NO_WINDOW,
+        NULL,
+        NULL,
+        &si,
+        &pi
+    );
+
+    if (!success) {
+        LogPrintf("runCommand error: CreateProcess(%s) failed: %d\n", strCommand, GetLastError());
+        return;
+    }
+
+    // Wait for the process to complete
+    WaitForSingleObject(pi.hProcess, INFINITE);
+
+    DWORD exitCode;
+    if (GetExitCodeProcess(pi.hProcess, &exitCode) && exitCode != 0) {
+        LogPrintf("runCommand error: process(%s) returned %lu\n", strCommand, exitCode);
+    }
+
+    CloseHandle(pi.hProcess);
+    CloseHandle(pi.hThread);
 #endif
-    if (nErr)
-        LogPrintf("runCommand error: system(%s) returned %d\n", strCommand, nErr);
 }
 #endif
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1897,11 +1897,8 @@ static void AlertNotify(const std::string& strMessage)
     if (strCmd.empty()) return;
 
     // Alert text should be plain ascii coming from a trusted source, but to
-    // be safe we first strip anything not in safeChars, then add single quotes around
-    // the whole string before passing it to the shell:
-    std::string singleQuote("'");
+    // be safe we first strip anything not in safeChars:
     std::string safeStatus = SanitizeString(strMessage);
-    safeStatus = singleQuote+safeStatus+singleQuote;
     ReplaceAll(strCmd, "%s", safeStatus);
 
     std::thread t(runCommand, strCmd);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1092,14 +1092,7 @@ CWalletTx* CWallet::AddToWallet(CTransactionRef tx, const TxState& state, const 
             ReplaceAll(strCmd, "%b", "unconfirmed");
             ReplaceAll(strCmd, "%h", "-1");
         }
-#ifndef WIN32
-        // Substituting the wallet name isn't currently supported on windows
-        // because windows shell escaping has not been implemented yet:
-        // https://github.com/bitcoin/bitcoin/pull/13339#issuecomment-537384875
-        // A few ways it could be implemented in the future are described in:
-        // https://github.com/bitcoin/bitcoin/pull/13339#issuecomment-461288094
-        ReplaceAll(strCmd, "%w", ShellEscape(GetName()));
-#endif
+        ReplaceAll(strCmd, "%w", GetName());
         std::thread t(runCommand, strCmd);
         t.detach(); // thread runs free
     }
@@ -4263,14 +4256,7 @@ void CWallet::notifyTransactionLock(const CTransactionRef &tx, const std::shared
         std::string strCmd = m_args.GetArg("-instantsendnotify", "");
         if (!strCmd.empty()) {
             ReplaceAll(strCmd, "%s", txHash.GetHex());
-#ifndef WIN32
-            // Substituting the wallet name isn't currently supported on windows
-            // because windows shell escaping has not been implemented yet:
-            // https://github.com/bitcoin/bitcoin/pull/13339#issuecomment-537384875
-            // A few ways it could be implemented in the future are described in:
-            // https://github.com/bitcoin/bitcoin/pull/13339#issuecomment-461288094
-            ReplaceAll(strCmd, "%w", ShellEscape(GetName()));
-#endif
+            ReplaceAll(strCmd, "%w", GetName());
             std::thread t(runCommand, strCmd);
             t.detach(); // thread runs free
         }


### PR DESCRIPTION
1. HMP Groth16 CRS was derived from a hardcoded public seed, making it
   possible for anyone to forge participation proofs. Changed to generate
   parameters with OS entropy (OsRng) and cache them to disk on first run
   instead.

2. blocknotify, walletnotify, chainlocknotify, instantsendnotify and
   alertnotify were using system() / _wsystem() which passes the command
   string to a shell. Replaced with fork+exec on Linux and CreateProcessW
   on Windows so arguments can never be interpreted as shell commands.
   Wallet name (%w) substitution now works on all platforms too.

3. External signer command path, fingerprint and descriptor arguments
   weren't validated before being passed to the subprocess. Added checks
   that reject spaces and shell metacharacters in all three inputs.